### PR TITLE
fix url for functions.sh

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -36,7 +36,7 @@ LOWERAPP="$(echo "$APP" | tr '[:upper:]' '[:lower:]')"
 VERSION="$2"
 
 mkdir -p $APP.AppDir
-wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+wget -q https://github.com/AppImage/AppImages/raw/master/functions.sh -O ./functions.sh
 . ./functions.sh
 
 LIB_DIR=./usr/lib


### PR DESCRIPTION
## Description
* the url for script functions.sh was changed, see [functions.sh](https://github.com/AppImage/AppImages/raw/master/functions.sh)

## Motivation and context
* for information, **bug** on appImage: functions.sh don't build on debian, see [pull request](https://github.com/AppImage/AppImages/pull/252) then release-tool don't work.   
  the PR was accepted, and it is **important** for debian platforms

## How has this been tested?

before PR 252, I can't build with release-tool, on Stretch or Sid
after, yes

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. 
- ✅ My code follows the code style of this project. 
- ✅  release-tool build appsImage with version 2.2.0

